### PR TITLE
Fix image id override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ module "labels" {
 resource "digitalocean_droplet" "main" {
   count = var.droplet_enabled == true ? var.droplet_count : 0
 
-  image              = join("", data.digitalocean_image.official.*.id)
+  image              = coalesce(var.image_id, join("", data.digitalocean_image.official.*.id))
   name               = format("%s%s%s", module.labels.id, var.delimiter, (count.index))
   region             = coalesce(local.region[var.region], var.region)
   size               = coalesce(local.sizes[var.droplet_size], var.droplet_size)


### PR DESCRIPTION
## what
* coalesce `var.image_id` or lookup image id based on provided slug

## why
* Fixes `var.image_id` as it is defined but not used
* Implement as part of image override

## references
https://github.com/clouddrove/terraform-digitalocean-droplet/issues/12
